### PR TITLE
Related works expansion

### DIFF
--- a/paper.bib
+++ b/paper.bib
@@ -25,11 +25,19 @@
   publisher={JMLR. org}
 }
 
-@article{blei2010supervised,
-	title={Supervised topic models},
-	author={Blei, David M and McAuliffe, Jon D},
-	journal={arXiv preprint arXiv:1003.0783},
-	year={2010}
+@inproceedings{blei2010supervised,
+	author = {Blei, David M. and McAuliffe, Jon D.},
+	title = {Supervised Topic Models},
+	year = {2007},
+	isbn = {9781605603520},
+	publisher = {Curran Associates Inc.},
+	address = {Red Hook, NY, USA},
+	abstract = {We introduce supervised latent Dirichlet allocation (sLDA), a statistical model of labelled documents. The model accommodates a variety of response types. We derive a maximum-likelihood procedure for parameter estimation, which relies on variational approximations to handle intractable posterior expectations. Prediction problems motivate this research: we use the fitted model to predict response values for new documents. We test sLDA on two real-world problems: movie ratings predicted from reviews, and web page popularity predicted from text descriptions. We illustrate the benefits of sLDA versus modern regularized regression, as well as versus an unsupervised LDA analysis followed by a separate regression.},
+	booktitle = {Proceedings of the 20th International Conference on Neural Information Processing Systems},
+	pages = {121–128},
+	numpages = {8},
+	location = {Vancouver, British Columbia, Canada},
+	series = {NIPS'07}
 }
 
 @inproceedings{mimno2008topic,
@@ -151,4 +159,46 @@ journal = {Commun. ACM},
 month = apr,
 pages = {77–84},
 numpages = {8}
+}
+
+@inproceedings{llda2009,
+	title = "{L}abeled {LDA}: A supervised topic model for credit attribution in multi-labeled corpora",
+	author = "Ramage, Daniel  and
+	Hall, David  and
+	Nallapati, Ramesh  and
+	Manning, Christopher D.",
+	booktitle = "Proceedings of the 2009 Conference on Empirical Methods in Natural Language Processing",
+	month = aug,
+	year = "2009",
+	address = "Singapore",
+	publisher = "Association for Computational Linguistics",
+	url = "https://www.aclweb.org/anthology/D09-1026",
+	pages = "248--256",
+}
+
+@inproceedings{wf-lda2010,
+	author = {Petterson, James and Buntine, Wray and Narayanamurthy, Shravan and Caetano, Tib\'{e}rio and Smola, Alex},
+	booktitle = {Advances in Neural Information Processing Systems},
+	editor = {J. Lafferty and C. Williams and J. Shawe-Taylor and R. Zemel and A. Culotta},
+	pages = {},
+	publisher = {Curran Associates, Inc.},
+	title = {Word Features for Latent Dirichlet Allocation},
+	url = {https://proceedings.neurips.cc/paper/2010/file/db85e2590b6109813dafa101ceb2faeb-Paper.pdf},
+	volume = {23},
+	year = {2010}
+}
+
+@article{lf-lda2015,
+	title = "Improving Topic Models with Latent Feature Word Representations",
+	author = "Nguyen, Dat Quoc  and
+	Billingsley, Richard  and
+	Du, Lan  and
+	Johnson, Mark",
+	journal = "Transactions of the Association for Computational Linguistics",
+	volume = "3",
+	year = "2015",
+	url = "https://www.aclweb.org/anthology/Q15-1022",
+	doi = "10.1162/tacl_a_00140",
+	pages = "299--313",
+	abstract = "Probabilistic topic models are widely used to discover latent topics in document collections, while latent feature vector representations of words have been used to obtain high performance in many NLP tasks. In this paper, we extend two different Dirichlet multinomial topic models by incorporating latent feature vector representations of words trained on very large corpora to improve the word-topic mapping learnt on a smaller corpus. Experimental results show that by using information from the external corpora, our new models produce significant improvements on topic coherence, document clustering and document classification tasks, especially on datasets with few or short documents.",
 }

--- a/paper.tex
+++ b/paper.tex
@@ -101,6 +101,7 @@ rech16@student.aau.dk}
 \bibliography{paper}
 
 %Appendixes, if needed, appear before the acknowledgment.
+\glsresetall
 \onecolumn
 \appendix
 \input{sections/appendix/Overview.tex}

--- a/sections/Dataset.tex
+++ b/sections/Dataset.tex
@@ -48,7 +48,7 @@ All of the category labels can be seen in \autoref{tab:category_table} in \autor
 	\label{fig:category_box}
 \end{figure}
 
-\subsection{Taxonomy}
+\subsection{Taxonomy}\label{sec:dataset_taxonomy}
 The taxonomy field describes a hierarchical structure of the topical or geographical subject of the articles.
 This field is only partially observed within the dataset, which means that ${\sim}25\%$ of the articles contain this field.
 Each article can contain multiple taxonomies.

--- a/sections/related_works.tex
+++ b/sections/related_works.tex
@@ -29,7 +29,7 @@ In order to verify that these metrics work, they conduct a large user study in c
 \citet{card2017neural} describe how to incorporate metadata information within a neural network to find topics using variational inference methods.
 
 There also exist a variety of models that look at either document or word metadata.
-Of models that incorporate document-level metadata, some examples are: Supervised LDA (sLDA) by \citet{blei2010supervised}, Labelled LDA (LLDA) by \citet{llda2009}, and the Dirichlet Multinomial Regression (DMR) model by \citet{mimno2008topic}.
+Some examples of models that incorporate document-level metadata are: Supervised LDA (sLDA) by \citet{blei2010supervised}, Labelled LDA (LLDA) by \citet{llda2009}, and the Dirichlet Multinomial Regression (DMR) model by \citet{mimno2008topic}.
 SLDA learns a model given the restriction of only having one label per document, while LLDA allows multiple labels per document, though it requires the number of topics to be the same as the number of unique labels.
 DMR handles metadata similarly to MetaLDA~\cite{MetaLDA2017} by incorporating labels on the prior of the documents' topic distributions.
 Examples of models that incorporate word-level metadata are: WF-LDA by \citet{wf-lda2010} and LF-LDA by \citet{lf-lda2015}.
@@ -40,5 +40,5 @@ From these works, we mainly use the concepts from \citet{author_topic_2012} for 
 There is one main reason why we use the concepts from the author-topic model instead of the newer MetaLDA model~\cite{MetaLDA2017}.
 In MetaLDA, each document has a specific Dirichlet prior for its topic distribution, which is computed from the metadata of the document.
 This limits the ability to analyze a model that includes multiple metadata, while in the author-topic model other metadata can be included as their own meta-topic distributions and be analyzed further.
-Also, since MetaLDA uses the document-topic distribution as its base, we wont be able to explore other interesting connections, such as the connection between learned category-topic distributions and the topics that are most probable for specific categories.
+Also, since MetaLDA uses the document-topic distribution as its base, we would not be able to explore other interesting connections, such as the connection between learned category-topic distributions and the topics that are most probable for specific categories.
 We also explore whether adapting the \gls{pam}~\cite{li2006pachinko} to work with a specific type of metadata called 'taxonomy', described in \autoref{sec:dataset_taxonomy}, will give the model more context and increased performance.

--- a/sections/related_works.tex
+++ b/sections/related_works.tex
@@ -28,9 +28,17 @@ In order to verify that these metrics work, they conduct a large user study in c
 
 \citet{card2017neural} describe how to incorporate metadata information within a neural network to find topics using variational inference methods.
 
+There also exist a variety of models that look at either document or word metadata.
+Of models that incorporate document-level metadata, some examples are: Supervised LDA (sLDA) by \citet{blei2010supervised}, Labelled LDA (LLDA) by \citet{llda2009}, and the Dirichlet Multinomial Regression (DMR) model by \citet{mimno2008topic}.
+SLDA learns a model given the restriction of only having one label per document, while LLDA allows multiple labels per document, though it requires the number of topics to be the same as the number of unique labels.
+DMR handles metadata similarly to MetaLDA~\cite{MetaLDA2017} by incorporating labels on the prior of the documents' topic distributions.
+Examples of models that incorporate word-level metadata are: WF-LDA by \citet{wf-lda2010} and LF-LDA by \citet{lf-lda2015}.
+WF-LDA extends \gls{lda} by using word features to make a prior for the topics.
+LF-LDA takes the approach of replacing \gls{lda}'s topic-word Dirichlet multinomial component with a two-component mixture of a topic-word Dirichlet multinomial component and a latent feature component.
+
 From these works, we mainly use the concepts from \citet{author_topic_2012} for how we use metadata in our models, though with slight changes in the models for handling the characteristics of our data.
 There is one main reason why we use the concepts from the author-topic model instead of the newer MetaLDA model~\cite{MetaLDA2017}.
 In MetaLDA, each document has a specific Dirichlet prior for its topic distribution, which is computed from the metadata of the document.
 This limits the ability to analyze a model that includes multiple metadata, while in the author-topic model other metadata can be included as their own meta-topic distributions and be analyzed further.
 Also, since MetaLDA uses the document-topic distribution as its base, we wont be able to explore other interesting connections, such as the connection between learned category-topic distributions and the topics that are most probable for specific categories.
-We also explore whether adapting the \gls{pam} to work with a specific type of metadata called 'taxonomy', described in \autoref{sec:dataset_taxonomy}, will give the model more context and increased performance.
+We also explore whether adapting the \gls{pam}~\cite{li2006pachinko} to work with a specific type of metadata called 'taxonomy', described in \autoref{sec:dataset_taxonomy}, will give the model more context and increased performance.

--- a/sections/related_works.tex
+++ b/sections/related_works.tex
@@ -14,11 +14,9 @@ The words from the topic-word distribution can be generated based on this topic.
 The purpose of using authorship information in this way, is to show patterns in which topics an author usually writes about, and be able to explore how related authors are in what they write about.
 \citeauthor{author_topic_2012} also show that the combination of authorship and \gls{lda} yield more coherent topics.
 
-
-\citet{MetaLDA2017} presents a recent model which can incorporate both metadata information and word embeddings within a topic model.
+\citet{MetaLDA2017} presents a recent model, called MetaLDA, which can incorporate both metadata information and word embeddings within a topic model.
 Since the field of incorporating word embeddings within generative topic models have gained popularity\cite{dieng2020topic}, \citet{MetaLDA2017} show how to use this information for a variety of different datasets.
 They also compare against a list of other models that take either metadata information or word embeddings into account when doing inference.
-
 
 \citet{tea_leaves} is a well-known paper within the topic modeling community, which presents different methods for evaluating probabilistic topic models. 
 An important observation they made, is that a good held-out likelihood, normally called perplexity, infers less semantically meaningful topics.
@@ -26,12 +24,13 @@ They also present two different human judgment methods, which can be used to eva
 \citet{topic_coherence_2015} introduce new measures for evaluating topic models, where some of them use the co-occurrence or conditional probability of words within topics to measure how coherent the topics are. 
 In order to verify that these metrics work, they conduct a large user study in conjunction with these metric evaluations.
 
-
-\citet{li2006pachinko} present a \gls{dag} structured topic model, called the \acrfull{pam}, where topics are in a hierarchical structure, which allows it to find two types of topics, namely super-topics and sub-topics. 
-
+\citet{li2006pachinko} present a \gls{dag} structured topic model, called the \gls{pam}, where topics are in a hierarchical structure, which allows it to find two types of topics, namely super-topics and sub-topics. 
 
 \citet{card2017neural} describe how to incorporate metadata information within a neural network to find topics using variational inference methods.
 
 From these works, we mainly use the concepts from \citet{author_topic_2012} for how we use metadata in our models, though with slight changes in the models for handling the characteristics of our data.
-
-\vejleder[inline]{what is our contribution?}
+There is one main reason why we use the concepts from the author-topic model instead of the newer MetaLDA model~\cite{MetaLDA2017}.
+In MetaLDA, each document has a specific Dirichlet prior for its topic distribution, which is computed from the metadata of the document.
+This limits the ability to analyze a model that includes multiple metadata, while in the author-topic model other metadata can be included as their own meta-topic distributions and be analyzed further.
+Also, since MetaLDA uses the document-topic distribution as its base, we wont be able to explore other interesting connections, such as the connection between learned category-topic distributions and the topics that are most probable for specific categories.
+We also explore whether adapting the \gls{pam} to work with a specific type of metadata called 'taxonomy', described in \autoref{sec:dataset_taxonomy}, will give the model more context and increased performance.


### PR DESCRIPTION
Udvidet related works med hvorfor vi ikke arbejdede med den nyere MetaLDA model.
Tilføjede også nogle af kilderne fra MetaLDA artiklen som vejledere har snakket om tidligere, med korte beskrivelser, så vi også kommer omkring at nogle også kigger på word-metadata.