### PR TITLE
Appendix metadata labels section restructure

### DIFF
--- a/paper.tex
+++ b/paper.tex
@@ -119,9 +119,7 @@ rech16@student.aau.dk}
 \input{sections/appendix/locking.tex}
 
 % Tables
-\input{sections/appendix/categories.tex}
-\input{sections/appendix/authors.tex}
-\input{sections/appendix/taxonomies.tex}
+\input{sections/appendix/metadata_labels.tex}
 
 % Applications
 \input{sections/appendix/applications.tex}

--- a/paper.tex
+++ b/paper.tex
@@ -121,6 +121,7 @@ rech16@student.aau.dk}
 % Tables
 \input{sections/appendix/categories.tex}
 \input{sections/appendix/authors.tex}
+\input{sections/appendix/taxonomies.tex}
 
 % Applications
 \input{sections/appendix/applications.tex}

--- a/sections/appendix/authors.tex
+++ b/sections/appendix/authors.tex
@@ -35,70 +35,71 @@ The name 'AAArtikler parkeret' also indicates that these articles, at least at s
 These articles are kept in our dataset, even though we can not be certain of who wrote them.
 
 \begin{table*}[h]
+	\caption{Number of documents written by each author in the Nordjyske dataset from 2017 to 2019.
+	The highlighted authors are filtered and combined during preprocessing.}
+	\label{tab:author_table}
 	\centering
 	\scriptsize
 	\begin{tabular}{l|c|l|c|l|c|l|c}
 		Author                & Number & Author                     & Number & Author                       & Number & Author                       & Number \\
-		\toprule
-		Ove Nørhave           &  9893  & Bent Stenbakken            &  646   & Katrine Schousboe            &  189   & Sarah Sandhøj                &   35   \\
-		System Administrator  &  9038  & Lars Hofmeister            &  628   & Mathias Majlund Laursen      &  178   & Suzanne Tram                 &   34   \\
-		Ole Fink Mejlgaard    &  6518  & Anne Helene Thomsen        &  606   & Anne Brik Jensen             &  177   & Sebastian Engelberth Hansen  &   33   \\
-		Peter Tordrup Larsen  &  5002  & Max Melgaard               &  587   & Peder Pedersen               &  166   & Anna Østergaard Bjørn        &   29   \\
-		Kim Juhl Andersen     &  4506  & Karen Marie Foldbjerg      &  580   & Carl Åge Østergaard          &  152   & Michael Sand Andersen        &   27   \\
-		Jeppe Damsgaard       &  4057  & Lise Larsen                &  575   & Mette Siggaard               &  150   & HANNE Lindblad Jensen        &   27   \\
-		Jørn Larsen           &  3863  & Asbjørn Hansen             &  566   & Karen Keinicke               &  150   & Mathilde Juul Back Jensen    &   25   \\
-		Jørn Eriksen          &  3395  & Peter Witten               &  544   & Tune Kristensen              &  149   & Allan Bauer                  &   19   \\
-		Anders Kjærgaard      &  2960  & Allan Vinding Sørensen     &  534   & Morten Brændstrup            &  146   & Linse Daugaard               &   18   \\
-		Søren Beukel Bak      &  2811  & Dorrit Gap Jensen          &  530   & Emil Halkier                 &  143   & Morten Nis Klenø             &   17   \\
-		Søren Olsson          &  2558  & Hans Christensen           &  500   & Britt Kristensen             &  135   & OLE SANVIG KNUDSEN           &   16   \\
-		Jens Peter Svarrer    &  2480  & Lars Høj                   &  493   & KAREN Marie Foldbjerg        &  132   & Frederik Siiger              &   15   \\
-		Flemming Kristensen   &  2282  & Jesper Ramsing             &  469   & Claus Smidstrup              &  128   & Kim Lesanner                 &   15   \\
-		Thomas Jasper         &  2186  & Jens Hukiær                &  464   & Sarah Thun Madsen            &  127   & Pia Haugaard                 &   13   \\
-		Bente Lembo           &  2128  & Svend Ole Jensen           &  447   & Jakob Kanne Bjerregaard      &  126   & MERETE HORN                  &   12   \\
-		Helle Møller Larsen   &  1787  & Martin Frandsen            &  437   & Lars Teilmann                &  122   & Regitze Ørnstrup Christensen &   12   \\
-		Claus Jensen          &  1739  & Tobias Brandt              &  423   & Natasha Jahanshahi           &  117   & Inge Steen Sørensen          &   11   \\
-		Esben Heine Pedersen  &  1689  & Andrea Jessen Jakobsen     &  423   & Jens Ole Pedersen            &  116   & Anika Thorø Møller           &   11   \\
-		Margit Sig            &  1632  & Carsten Søgaard Jensen     &  420   & Pauline Bülow                &  116   & Tim Søgaard                  &   11   \\
-		Jens Fogh-Andersen    &  1614  & Morten Lind                &  413   & Christoffer Green Sørensen   &  115   & Flemming Haslund             &   10   \\
-		Ole Jensen            &  1611  & Esben Agerlin Olsen        &  406   & Flemming Junker              &  103   & Henrik Nordstrøm Mortensen   &   10   \\
-		David Højmark         &  1549  & Carsten Hougaard           &  406   & Niklas Grønborg              &  103   & Emil Halkær                  &   9    \\
-		Niels Hansen          &  1512  & Dorit Glintborg            &  405   & Sofie Møller                 &   99   & Katrine Hjulmann Nielsen     &   9    \\
-		Line Lykkegaard Skou  &  1504  & Karin Pedersen             &  397   & Michael Strandfelt           &   98   & John Jensen                  &   8    \\
-		Lars Bang Bertelsen   &  1443  & Kasper Ørkild              &  393   & Anders Sønderup              &   95   & Jacob Eggert Kabel           &   8    \\
-		Villy Dall            &  1408  & Marianne Isen              &  387   & Søren Kjær                   &   95   & Søren Dietrichsen            &   7    \\
-		Hans Peter Kragh      &  1403  & Jakob Gammelgaard          &  385   & Lone Beck                    &   92   & Nicolai Østergaard           &   6    \\
-		Claus T. Kræmmergård  &  1354  & Dorte Geertsen             &  383   & Torben O. Andersen           &   91   & Søren L. Hviid               &   6    \\
-		Lars Christensen      &  1293  & Torben Duch Holm           &  364   & Mikkel Færgemann Viken       &   91   & Kathrine Lykkegaard Jeppesen &   5    \\
-		Rasmus Skovbo         &  1253  & Henrik Strømgaard          &  362   & Hans Henrik Rasmussen        &   90   & Ursula Rechnagel Taylor      &   5    \\
-		Anders Abildgaard     &  1229  & Lisbeth Helleskov          &  361   & Steffen Bek                  &   89   & Jens Otto Barsøe             &   4    \\
-		Lasse Damsgaard       &  1209  & Niels Brauer               &  358   & Simon Kjær Jensen            &   86   & Maria Berg Badstue Pedersen  &   4    \\
-		Søren Østergaard      &  1207  & Jesper Poulsen             &  348   & Michael Sand                 &   85   & Jacob Andersen               &   3    \\
-		Hanne Lindblad Jensen &  1191  & Lars Termansen             &  328   & Julian Drud Sørensen         &   84   & Christian Brahe-Pedersen     &   3    \\
-		Charlotte Bøje        &  1117  & Mikkel Eklund              &  328   & Tina Larsen                  &   82   & Helle-Lise Ritzau Kaptain    &   3    \\
-		Morten Kyndby Holm    &  1102  & Susie Skov                 &  323   & Nils Rasmussen               &   79   & Jane Schmidt Klausen         &   3    \\
-		Lars Aare Jensen      &  1084  & Birgitte Sonne             &  321   & Katrine Hjulmann             &   73   & Ebbe Fischer                 &   3    \\
-		Hanne Overbye         &  1075  & Anders Andersen            &  315   & Mathias Lykke                &   72   & Stefan Buur Hansen           &   3    \\
-		Lise Stenbro          &  1029  & Gunnar Onghamar            &  309   & Caspar Birk                  &   71   & Camilla Pehrson              &   2    \\
-		Lone Lærke Krog       &  1005  & Carl Emil Nielsen          &  305   & Anna Bech Sørensen           &   69   & Danske Fagmedier master      &   2    \\
-		Carsten Tolbøll       &  1004  & Emma Toftelund Poulsen     &  299   & Fie Dømler                   &   65   & testbruger                   &   2    \\
-		Mette Møller          &  974   & Ole Sanvig Knudsen         &  287   & Poul Christoffersen          &   65   & Anders Fuglsang              &   2    \\
-		Ida Smith             &  973   & Charlotte Rørth            &  276   & Søren Skov                   &   56   & Peter Kargaard               &   2    \\
-		Merete Horn           &  929   & Morten Appel               &  273   & Nana Sofia Hansen            &   54   & Morten Munk Andersen         &   2    \\
-		Pernille K. Damsgaard &  922   & Kristian Gull Pedersen     &  266   & Tobias Reffstrup Rasmussen   &   53   & JSLbruger Nordjyske          &   2    \\
-		Lars Løcke            &  873   & Birgitte Bové              &  262   & AAArtikler parkeret          &   51   & Jan M. Jensen                &   1    \\
-		Thomas Nielsen        &  841   & Helle Madsen               &  258   & Camilla Gammelgaard Johansen &   50   & Tom Andersson                &   1    \\
-		Jakob Frey Ahrentzen  &  832   & Kasper Orkild Hansen       &  255   & Klaus Færch Gjerulff         &   49   & Jørgen la Cour-Harbo         &   1    \\
-		Lise Myrup Lassen     &  793   & Emil Abkjær Kristensen     &  253   & Ida Thorsen                  &   48   & Rene Sonne                   &   1    \\
-		Carl Chr. Madsen      &  785   & Nanna Holm Hansen          &  252   & Mathias Overgaard            &   46   & SAXoTECH Systembruger        &   1    \\
-		Inge Nørregård        &  746   & Bine Martine Gori          &  247   & Kirsten Østergaard           &   45   & Andreas K. Wielandt          &   1    \\
-		Jesper Schouenborg    &  724   & Heidi Majgaard B. Pedersen &  244   & Gerda Buhl Andersen          &   44   & Per Lyngby                   &   1    \\
-		Jens Sønderup         &  709   & Daniel Vendner             &  211   & Pia Christensen              &   44   & Michael F. Nørfelt           &   1    \\
-		Birgit Eriksen        &  700   & Ida Marie Kristensen       &  204   & Dorte Rohde                  &   42   & Simon Dinsen Hansen          &   1    \\
-		Søren Wormslev        &  681   & Kirsten Pilgaard           &  197   & Anna Grethe Jensen           &   41   & Mads Skov Aagurd             &   1    \\
-		Knud Labohn           &  653   & Marianne Dyhrberg Cornett  &  192   & Henrik Schulz                &   38   & Benita Dreyer-Andersen       &   1    \\
-		Hans Jørgen Hansen    &  646   & Susanne Justsen            &  191   & Lone Heilskov                &   37   &                              &        \\
+		\midrule
+		Ove Nørhave & 9893 & Bent Stenbakken & 646 & Katrine Schousboe & 189 & \textbf{Sarah Sandhøj} & 35 \\
+		System Administrator & 9038 & Lars Hofmeister & 628 & Mathias Majlund Laursen & 178 & \textbf{Suzanne Tram} & 34 \\
+		Ole Fink Mejlgaard & 6518 & Anne Helene Thomsen & 606 & Anne Brik Jensen & 177 & \textbf{Sebastian Engelberth Hansen} & 33 \\
+		Peter Tordrup Larsen & 5002 & Max Melgaard & 587 & Peder Pedersen & 166 & \textbf{Anna Østergaard Bjørn} & 29 \\
+		Kim Juhl Andersen & 4506 & Karen Marie Foldbjerg & 580 & Carl Åge Østergaard & 152 & \textbf{Michael Sand Andersen} & 27 \\
+		Jeppe Damsgaard & 4057 & Lise Larsen & 575 & Mette Siggaard & 150 & \textbf{HANNE Lindblad Jensen} & 27 \\
+		Jørn Larsen & 3863 & Asbjørn Hansen & 566 & Karen Keinicke & 150 & \textbf{Mathilde Juul Back Jensen} & 25 \\
+		Jørn Eriksen & 3395 & Peter Witten & 544 & Tune Kristensen & 149 & \textbf{Allan Bauer} & 19 \\
+		Anders Kjærgaard & 2960 & Allan Vinding Sørensen & 534 & Morten Brændstrup & 146 & \textbf{Linse Daugaard} & 18 \\
+		Søren Beukel Bak & 2811 & Dorrit Gap Jensen & 530 & Emil Halkier & 143 & \textbf{Morten Nis Klenø} & 17 \\
+		Søren Olsson & 2558 & Hans Christensen & 500 & \textbf{Britt Kristensen} & 135 & \textbf{OLE SANVIG KNUDSEN} & 16 \\
+		Jens Peter Svarrer & 2480 & Lars Høj & 493 & \textbf{KAREN Marie Foldbjerg} & 132 & \textbf{Frederik Siiger} & 15 \\
+		Flemming Kristensen & 2282 & Jesper Ramsing & 469 & \textbf{Claus Smidstrup} & 128 & \textbf{Kim Lesanner} & 15 \\
+		Thomas Jasper & 2186 & Jens Hukiær & 464 & \textbf{Sarah Thun Madsen} & 127 & \textbf{Pia Haugaard} & 13 \\
+		Bente Lembo & 2128 & Svend Ole Jensen & 447 & \textbf{Jakob Kanne Bjerregaard} & 126 & \textbf{MERETE HORN} & 12 \\
+		Helle Møller Larsen & 1787 & Martin Frandsen & 437 & \textbf{Lars Teilmann} & 122 & \textbf{Regitze Ørnstrup Christensen} & 12 \\
+		Claus Jensen & 1739 & Tobias Brandt & 423 & \textbf{Natasha Jahanshahi} & 117 & \textbf{Inge Steen Sørensen} & 11 \\
+		Esben Heine Pedersen & 1689 & Andrea Jessen Jakobsen & 423 & \textbf{Jens Ole Pedersen} & 116 & \textbf{Anika Thorø Møller} & 11 \\
+		Margit Sig & 1632 & Carsten Søgaard Jensen & 420 & \textbf{Pauline Bülow} & 116 & \textbf{Tim Søgaard} & 11 \\
+		Jens Fogh-Andersen & 1614 & Morten Lind & 413 & \textbf{Christoffer Green Sørensen} & 115 & \textbf{Flemming Haslund} & 10 \\
+		Ole Jensen & 1611 & Esben Agerlin Olsen & 406 & \textbf{Flemming Junker} & 103 & \textbf{Henrik Nordstrøm Mortensen} & 10 \\
+		David Højmark & 1549 & Carsten Hougaard & 406 & \textbf{Niklas Grønborg} & 103 & \textbf{Emil Halkær} & 9 \\
+		Niels Hansen & 1512 & Dorit Glintborg & 405 & \textbf{Sofie Møller} & 99 & \textbf{Katrine Hjulmann Nielsen} & 9 \\
+		Line Lykkegaard Skou & 1504 & Karin Pedersen & 397 & \textbf{Michael Strandfelt} & 98 & \textbf{John Jensen} & 8 \\
+		Lars Bang Bertelsen & 1443 & Kasper Ørkild & 393 & \textbf{Anders Sønderup} & 95 & \textbf{Jacob Eggert Kabel} & 8 \\
+		Villy Dall & 1408 & Marianne Isen & 387 & \textbf{Søren Kjær} & 95 & \textbf{Søren Dietrichsen} & 7 \\
+		Hans Peter Kragh & 1403 & Jakob Gammelgaard & 385 & \textbf{Lone Beck} & 92 & \textbf{Nicolai Østergaard} & 6 \\
+		Claus T. Kræmmergård & 1354 & Dorte Geertsen & 383 & \textbf{Torben O. Andersen} & 91 & \textbf{Søren L. Hviid} & 6 \\
+		Lars Christensen & 1293 & Torben Duch Holm & 364 & \textbf{Mikkel Færgemann Viken} & 91 & \textbf{Kathrine Lykkegaard Jeppesen} & 5 \\
+		Rasmus Skovbo & 1253 & Henrik Strømgaard & 362 & \textbf{Hans Henrik Rasmussen} & 90 & \textbf{Ursula Rechnagel Taylor} & 5 \\
+		Anders Abildgaard & 1229 & Lisbeth Helleskov & 361 & \textbf{Steffen Bek} & 89 & \textbf{Jens Otto Barsøe} & 4 \\
+		Lasse Damsgaard & 1209 & Niels Brauer & 358 & \textbf{Simon Kjær Jensen} & 86 & \textbf{Maria Berg Badstue Pedersen} & 4 \\
+		Søren Østergaard & 1207 & Jesper Poulsen & 348 & \textbf{Michael Sand} & 85 & \textbf{Jacob Andersen} & 3 \\
+		Hanne Lindblad Jensen & 1191 & Lars Termansen & 328 & \textbf{Julian Drud Sørensen} & 84 & \textbf{Christian Brahe-Pedersen} & 3 \\
+		Charlotte Bøje & 1117 & Mikkel Eklund & 328 & \textbf{Tina Larsen} & 82 & \textbf{Helle-Lise Ritzau Kaptain} & 3 \\
+		Morten Kyndby Holm & 1102 & Susie Skov & 323 & \textbf{Nils Rasmussen} & 79 & \textbf{Jane Schmidt Klausen} & 3 \\
+		Lars Aare Jensen & 1084 & Birgitte Sonne & 321 & \textbf{Katrine Hjulmann} & 73 & \textbf{Ebbe Fischer} & 3 \\
+		Hanne Overbye & 1075 & Anders Andersen & 315 & \textbf{Mathias Lykke} & 72 & \textbf{Stefan Buur Hansen} & 3 \\
+		Lise Stenbro & 1029 & Gunnar Onghamar & 309 & \textbf{Caspar Birk} & 71 & \textbf{Camilla Pehrson} & 2 \\
+		Lone Lærke Krog & 1005 & Carl Emil Nielsen & 305 & \textbf{Anna Bech Sørensen} & 69 & \textbf{Danske Fagmedier master} & 2 \\
+		Carsten Tolbøll & 1004 & Emma Toftelund Poulsen & 299 & \textbf{Fie Dømler} & 65 & \textbf{testbruger} & 2 \\
+		Mette Møller & 974 & Ole Sanvig Knudsen & 287 & \textbf{Poul Christoffersen} & 65 & \textbf{Anders Fuglsang} & 2 \\
+		Ida Smith & 973 & Charlotte Rørth & 276 & \textbf{Søren Skov} & 56 & \textbf{Peter Kargaard} & 2 \\
+		Merete Horn & 929 & Morten Appel & 273 & \textbf{Nana Sofia Hansen} & 54 & \textbf{Morten Munk Andersen} & 2 \\
+		Pernille K. Damsgaard & 922 & Kristian Gull Pedersen & 266 & \textbf{Tobias Reffstrup Rasmussen} & 53 & \textbf{JSLbruger Nordjyske} & 2 \\
+		Lars Løcke & 873 & Birgitte Bové & 262 & \textbf{AAArtikler parkeret} & 51 & \textbf{Jan M. Jensen} & 1 \\
+		Thomas Nielsen & 841 & Helle Madsen & 258 & \textbf{Camilla Gammelgaard Johansen} & 50 & \textbf{Tom Andersson} & 1 \\
+		Jakob Frey Ahrentzen & 832 & Kasper Orkild Hansen & 255 & \textbf{Klaus Færch Gjerulff} & 49 & \textbf{Jørgen la Cour-Harbo} & 1 \\
+		Lise Myrup Lassen & 793 & Emil Abkjær Kristensen & 253 & \textbf{Ida Thorsen} & 48 & \textbf{Rene Sonne} & 1 \\
+		Carl Chr. Madsen & 785 & Nanna Holm Hansen & 252 & \textbf{Mathias Overgaard} & 46 & \textbf{SAXoTECH Systembruger} & 1 \\
+		Inge Nørregård & 746 & Bine Martine Gori & 247 & \textbf{Kirsten Østergaard} & 45 & \textbf{Andreas K. Wielandt} & 1 \\
+		Jesper Schouenborg & 724 & Heidi Majgaard B. Pedersen & 244 & \textbf{Gerda Buhl Andersen} & 44 & \textbf{Per Lyngby} & 1 \\
+		Jens Sønderup & 709 & Daniel Vendner & 211 & \textbf{Pia Christensen} & 44 & \textbf{Michael F. Nørfelt} & 1 \\
+		Birgit Eriksen & 700 & Ida Marie Kristensen & 204 & \textbf{Dorte Rohde} & 42 & \textbf{Simon Dinsen Hansen} & 1 \\
+		Søren Wormslev & 681 & Kirsten Pilgaard & 197 & \textbf{Anna Grethe Jensen} & 41 & \textbf{Mads Skov Aagurd} & 1 \\
+		Knud Labohn & 653 & Marianne Dyhrberg Cornett & 192 & \textbf{Henrik Schulz} & 38 & \textbf{Benita Dreyer-Andersen} & 1 \\
+		Hans Jørgen Hansen & 646 & Susanne Justsen & 191 & \textbf{Lone Heilskov} & 37 & & \\
 		\bottomrule
 	\end{tabular}
-	\caption{Number of documents written by each author in the Nordjyske dataset from 2017 to 2019.}
-	\label{tab:author_table}
 \end{table*}

--- a/sections/appendix/authors.tex
+++ b/sections/appendix/authors.tex
@@ -1,4 +1,4 @@
-\subsubsection{Author Metadata}
+\subsubsection{Author}\label{subsec:appendix_author}
 There are a total of $227$ authors within the dataset where each author on average have written $757$ articles from 2017 to 2019.
 An interesting fact is that the median is $316$ which is much lower than the average which is visible in \autoref{fig:author_histogram}.
 This shows that while most authors have written just a few hundred articles, there is a small amount of authors that have written thousands of articles, increasing the average.
@@ -11,11 +11,10 @@ When we look at the top two most writing authors, we get these:
 	\end{itemize}
 	\item System Administrator (9038 articles)
 	\begin{itemize}
-		\item We are not sure why this has been used, it could be a placeholder.
+		\item We are not sure why this has been used. It could be a placeholder.
 	\end{itemize}
 \end{itemize}
 
- 
 \begin{figure}
 	\centering
 	\includegraphics[width=.7\linewidth]{figures/author_hist_plot.pdf}
@@ -24,6 +23,51 @@ When we look at the top two most writing authors, we get these:
 \end{figure}
 In \autoref{fig:author_histogram}, we see that the vast majority of authors have written under $2000$ articles within the three years. 
 All authors and the number of articles they have written can be seen in \autoref{tab:author_table}.
+
+Unlike with Categories, the Author metadata field does not have a natural cut-off point, with a good amount of values in a specific lower range, followed by more evenly distributed numbers.
+Instead, the vast majority of the values fall in a lower range, meaning that setting too high a cut-off point, will result in removing a large portion of the data.
+We instead choose a lower cut-off point, keeping most of the authors, except the ones that contained so few documents, that finding common topics would be inefficient.
+Authors, who have written less than $14$ documents ($0.01\%$ of the number of documents), are removed as part of preprocessing.
+This removes $43$ out of $227$ authors, combining them into a single 'misc' author.
+A total of $204$ documents are assigned to the 'misc' author.
+\todo[inline]{figure out whether to use boxplots or histograms, and ref them.}
+
+\begin{figure*}[ht]
+	\centering
+	\begin{subfigure}{0.45\textwidth}
+		\centering
+		\includegraphics[width=\linewidth]{figures/author_hist2_before.png}
+		\caption{Before preprocessing}
+		\label{fig:author_hist_before}
+	\end{subfigure}
+	\begin{subfigure}{0.45\textwidth}
+		\centering
+		\includegraphics[width=\linewidth]{figures/author_hist2_14.png}
+		\caption{After preprocessing}
+		\label{fig:auhtor_hist_after}
+	\end{subfigure}
+	\caption{Histogram over amount authors who have written certain number of documents, before and after preprocessing.
+		Authors on the x-axis are grouped into 50 buckets.}
+	\label{fig:author_hist}
+\end{figure*}
+
+\begin{figure*}[ht]
+	\centering
+	\begin{subfigure}{0.45\textwidth}
+		\centering
+		\includegraphics[width=\linewidth]{figures/author_box_before.png}
+		\caption{Before preprocessing}
+		\label{fig:author_box_before}
+	\end{subfigure}
+	\begin{subfigure}{0.45\textwidth}
+		\centering
+		\includegraphics[width=\linewidth]{figures/author_box_14.png}
+		\caption{After preprocessing}
+		\label{fig:auhtor_box_after}
+	\end{subfigure}
+	\caption{Boxplot over the amount of documents written by authors.}
+	\label{fig:author_box}
+\end{figure*}
 
 Other than the 'System Administrator' author, there are a few authors that seem different since they do not have the name of a person.
 These are: 'SAXoTECH Systembruger' with 1 article, 'JSLbruger Nordjyske', 'testbruger', and 'Danske Fagmedier master' with 2 articles, and 'AAArtikler parkeret' with 51 articles.
@@ -43,63 +87,63 @@ These articles are kept in our dataset, even though we can not be certain of who
 	\begin{tabular}{l|c|l|c|l|c|l|c}
 		Author                & Number & Author                     & Number & Author                       & Number & Author                       & Number \\
 		\midrule
-		Ove Nørhave & 9893 & Bent Stenbakken & 646 & Katrine Schousboe & 189 & \textbf{Sarah Sandhøj} & 35 \\
-		System Administrator & 9038 & Lars Hofmeister & 628 & Mathias Majlund Laursen & 178 & \textbf{Suzanne Tram} & 34 \\
-		Ole Fink Mejlgaard & 6518 & Anne Helene Thomsen & 606 & Anne Brik Jensen & 177 & \textbf{Sebastian Engelberth Hansen} & 33 \\
-		Peter Tordrup Larsen & 5002 & Max Melgaard & 587 & Peder Pedersen & 166 & \textbf{Anna Østergaard Bjørn} & 29 \\
-		Kim Juhl Andersen & 4506 & Karen Marie Foldbjerg & 580 & Carl Åge Østergaard & 152 & \textbf{Michael Sand Andersen} & 27 \\
-		Jeppe Damsgaard & 4057 & Lise Larsen & 575 & Mette Siggaard & 150 & \textbf{HANNE Lindblad Jensen} & 27 \\
-		Jørn Larsen & 3863 & Asbjørn Hansen & 566 & Karen Keinicke & 150 & \textbf{Mathilde Juul Back Jensen} & 25 \\
-		Jørn Eriksen & 3395 & Peter Witten & 544 & Tune Kristensen & 149 & \textbf{Allan Bauer} & 19 \\
-		Anders Kjærgaard & 2960 & Allan Vinding Sørensen & 534 & Morten Brændstrup & 146 & \textbf{Linse Daugaard} & 18 \\
-		Søren Beukel Bak & 2811 & Dorrit Gap Jensen & 530 & Emil Halkier & 143 & \textbf{Morten Nis Klenø} & 17 \\
-		Søren Olsson & 2558 & Hans Christensen & 500 & \textbf{Britt Kristensen} & 135 & \textbf{OLE SANVIG KNUDSEN} & 16 \\
-		Jens Peter Svarrer & 2480 & Lars Høj & 493 & \textbf{KAREN Marie Foldbjerg} & 132 & \textbf{Frederik Siiger} & 15 \\
-		Flemming Kristensen & 2282 & Jesper Ramsing & 469 & \textbf{Claus Smidstrup} & 128 & \textbf{Kim Lesanner} & 15 \\
-		Thomas Jasper & 2186 & Jens Hukiær & 464 & \textbf{Sarah Thun Madsen} & 127 & \textbf{Pia Haugaard} & 13 \\
-		Bente Lembo & 2128 & Svend Ole Jensen & 447 & \textbf{Jakob Kanne Bjerregaard} & 126 & \textbf{MERETE HORN} & 12 \\
-		Helle Møller Larsen & 1787 & Martin Frandsen & 437 & \textbf{Lars Teilmann} & 122 & \textbf{Regitze Ørnstrup Christensen} & 12 \\
-		Claus Jensen & 1739 & Tobias Brandt & 423 & \textbf{Natasha Jahanshahi} & 117 & \textbf{Inge Steen Sørensen} & 11 \\
-		Esben Heine Pedersen & 1689 & Andrea Jessen Jakobsen & 423 & \textbf{Jens Ole Pedersen} & 116 & \textbf{Anika Thorø Møller} & 11 \\
-		Margit Sig & 1632 & Carsten Søgaard Jensen & 420 & \textbf{Pauline Bülow} & 116 & \textbf{Tim Søgaard} & 11 \\
-		Jens Fogh-Andersen & 1614 & Morten Lind & 413 & \textbf{Christoffer Green Sørensen} & 115 & \textbf{Flemming Haslund} & 10 \\
-		Ole Jensen & 1611 & Esben Agerlin Olsen & 406 & \textbf{Flemming Junker} & 103 & \textbf{Henrik Nordstrøm Mortensen} & 10 \\
-		David Højmark & 1549 & Carsten Hougaard & 406 & \textbf{Niklas Grønborg} & 103 & \textbf{Emil Halkær} & 9 \\
-		Niels Hansen & 1512 & Dorit Glintborg & 405 & \textbf{Sofie Møller} & 99 & \textbf{Katrine Hjulmann Nielsen} & 9 \\
-		Line Lykkegaard Skou & 1504 & Karin Pedersen & 397 & \textbf{Michael Strandfelt} & 98 & \textbf{John Jensen} & 8 \\
-		Lars Bang Bertelsen & 1443 & Kasper Ørkild & 393 & \textbf{Anders Sønderup} & 95 & \textbf{Jacob Eggert Kabel} & 8 \\
-		Villy Dall & 1408 & Marianne Isen & 387 & \textbf{Søren Kjær} & 95 & \textbf{Søren Dietrichsen} & 7 \\
-		Hans Peter Kragh & 1403 & Jakob Gammelgaard & 385 & \textbf{Lone Beck} & 92 & \textbf{Nicolai Østergaard} & 6 \\
-		Claus T. Kræmmergård & 1354 & Dorte Geertsen & 383 & \textbf{Torben O. Andersen} & 91 & \textbf{Søren L. Hviid} & 6 \\
-		Lars Christensen & 1293 & Torben Duch Holm & 364 & \textbf{Mikkel Færgemann Viken} & 91 & \textbf{Kathrine Lykkegaard Jeppesen} & 5 \\
-		Rasmus Skovbo & 1253 & Henrik Strømgaard & 362 & \textbf{Hans Henrik Rasmussen} & 90 & \textbf{Ursula Rechnagel Taylor} & 5 \\
-		Anders Abildgaard & 1229 & Lisbeth Helleskov & 361 & \textbf{Steffen Bek} & 89 & \textbf{Jens Otto Barsøe} & 4 \\
-		Lasse Damsgaard & 1209 & Niels Brauer & 358 & \textbf{Simon Kjær Jensen} & 86 & \textbf{Maria Berg Badstue Pedersen} & 4 \\
-		Søren Østergaard & 1207 & Jesper Poulsen & 348 & \textbf{Michael Sand} & 85 & \textbf{Jacob Andersen} & 3 \\
-		Hanne Lindblad Jensen & 1191 & Lars Termansen & 328 & \textbf{Julian Drud Sørensen} & 84 & \textbf{Christian Brahe-Pedersen} & 3 \\
-		Charlotte Bøje & 1117 & Mikkel Eklund & 328 & \textbf{Tina Larsen} & 82 & \textbf{Helle-Lise Ritzau Kaptain} & 3 \\
-		Morten Kyndby Holm & 1102 & Susie Skov & 323 & \textbf{Nils Rasmussen} & 79 & \textbf{Jane Schmidt Klausen} & 3 \\
-		Lars Aare Jensen & 1084 & Birgitte Sonne & 321 & \textbf{Katrine Hjulmann} & 73 & \textbf{Ebbe Fischer} & 3 \\
-		Hanne Overbye & 1075 & Anders Andersen & 315 & \textbf{Mathias Lykke} & 72 & \textbf{Stefan Buur Hansen} & 3 \\
-		Lise Stenbro & 1029 & Gunnar Onghamar & 309 & \textbf{Caspar Birk} & 71 & \textbf{Camilla Pehrson} & 2 \\
-		Lone Lærke Krog & 1005 & Carl Emil Nielsen & 305 & \textbf{Anna Bech Sørensen} & 69 & \textbf{Danske Fagmedier master} & 2 \\
-		Carsten Tolbøll & 1004 & Emma Toftelund Poulsen & 299 & \textbf{Fie Dømler} & 65 & \textbf{testbruger} & 2 \\
-		Mette Møller & 974 & Ole Sanvig Knudsen & 287 & \textbf{Poul Christoffersen} & 65 & \textbf{Anders Fuglsang} & 2 \\
-		Ida Smith & 973 & Charlotte Rørth & 276 & \textbf{Søren Skov} & 56 & \textbf{Peter Kargaard} & 2 \\
-		Merete Horn & 929 & Morten Appel & 273 & \textbf{Nana Sofia Hansen} & 54 & \textbf{Morten Munk Andersen} & 2 \\
-		Pernille K. Damsgaard & 922 & Kristian Gull Pedersen & 266 & \textbf{Tobias Reffstrup Rasmussen} & 53 & \textbf{JSLbruger Nordjyske} & 2 \\
-		Lars Løcke & 873 & Birgitte Bové & 262 & \textbf{AAArtikler parkeret} & 51 & \textbf{Jan M. Jensen} & 1 \\
-		Thomas Nielsen & 841 & Helle Madsen & 258 & \textbf{Camilla Gammelgaard Johansen} & 50 & \textbf{Tom Andersson} & 1 \\
-		Jakob Frey Ahrentzen & 832 & Kasper Orkild Hansen & 255 & \textbf{Klaus Færch Gjerulff} & 49 & \textbf{Jørgen la Cour-Harbo} & 1 \\
-		Lise Myrup Lassen & 793 & Emil Abkjær Kristensen & 253 & \textbf{Ida Thorsen} & 48 & \textbf{Rene Sonne} & 1 \\
-		Carl Chr. Madsen & 785 & Nanna Holm Hansen & 252 & \textbf{Mathias Overgaard} & 46 & \textbf{SAXoTECH Systembruger} & 1 \\
-		Inge Nørregård & 746 & Bine Martine Gori & 247 & \textbf{Kirsten Østergaard} & 45 & \textbf{Andreas K. Wielandt} & 1 \\
-		Jesper Schouenborg & 724 & Heidi Majgaard B. Pedersen & 244 & \textbf{Gerda Buhl Andersen} & 44 & \textbf{Per Lyngby} & 1 \\
-		Jens Sønderup & 709 & Daniel Vendner & 211 & \textbf{Pia Christensen} & 44 & \textbf{Michael F. Nørfelt} & 1 \\
-		Birgit Eriksen & 700 & Ida Marie Kristensen & 204 & \textbf{Dorte Rohde} & 42 & \textbf{Simon Dinsen Hansen} & 1 \\
-		Søren Wormslev & 681 & Kirsten Pilgaard & 197 & \textbf{Anna Grethe Jensen} & 41 & \textbf{Mads Skov Aagurd} & 1 \\
-		Knud Labohn & 653 & Marianne Dyhrberg Cornett & 192 & \textbf{Henrik Schulz} & 38 & \textbf{Benita Dreyer-Andersen} & 1 \\
-		Hans Jørgen Hansen & 646 & Susanne Justsen & 191 & \textbf{Lone Heilskov} & 37 & & \\
+		Ove Nørhave & 9893 & Bent Stenbakken & 646 & Katrine Schousboe & 189 & Sarah Sandhøj & 35 \\
+		System Administrator & 9038 & Lars Hofmeister & 628 & Mathias Majlund Laursen & 178 & Suzanne Tram & 34 \\
+		Ole Fink Mejlgaard & 6518 & Anne Helene Thomsen & 606 & Anne Brik Jensen & 177 & Sebastian Engelberth Hansen & 33 \\
+		Peter Tordrup Larsen & 5002 & Max Melgaard & 587 & Peder Pedersen & 166 & Anna Østergaard Bjørn & 29 \\
+		Kim Juhl Andersen & 4506 & Karen Marie Foldbjerg & 580 & Carl Åge Østergaard & 152 & Michael Sand Andersen & 27 \\
+		Jeppe Damsgaard & 4057 & Lise Larsen & 575 & Mette Siggaard & 150 & HANNE Lindblad Jensen & 27 \\
+		Jørn Larsen & 3863 & Asbjørn Hansen & 566 & Karen Keinicke & 150 & Mathilde Juul Back Jensen & 25 \\
+		Jørn Eriksen & 3395 & Peter Witten & 544 & Tune Kristensen & 149 & Allan Bauer & 19 \\
+		Anders Kjærgaard & 2960 & Allan Vinding Sørensen & 534 & Morten Brændstrup & 146 & Linse Daugaard & 18 \\
+		Søren Beukel Bak & 2811 & Dorrit Gap Jensen & 530 & Emil Halkier & 143 & Morten Nis Klenø & 17 \\
+		Søren Olsson & 2558 & Hans Christensen & 500 & Britt Kristensen & 135 & OLE SANVIG KNUDSEN & 16 \\
+		Jens Peter Svarrer & 2480 & Lars Høj & 493 & KAREN Marie Foldbjerg & 132 & Frederik Siiger & 15 \\
+		Flemming Kristensen & 2282 & Jesper Ramsing & 469 & Claus Smidstrup & 128 & Kim Lesanner & 15 \\
+		Thomas Jasper & 2186 & Jens Hukiær & 464 & Sarah Thun Madsen & 127 & \textbf{Pia Haugaard} & 13 \\
+		Bente Lembo & 2128 & Svend Ole Jensen & 447 & Jakob Kanne Bjerregaard & 126 & \textbf{MERETE HORN} & 12 \\
+		Helle Møller Larsen & 1787 & Martin Frandsen & 437 & Lars Teilmann & 122 & \textbf{Regitze Ørnstrup Christensen} & 12 \\
+		Claus Jensen & 1739 & Tobias Brandt & 423 & Natasha Jahanshahi & 117 & \textbf{Inge Steen Sørensen} & 11 \\
+		Esben Heine Pedersen & 1689 & Andrea Jessen Jakobsen & 423 & Jens Ole Pedersen & 116 & \textbf{Anika Thorø Møller} & 11 \\
+		Margit Sig & 1632 & Carsten Søgaard Jensen & 420 & Pauline Bülow & 116 & \textbf{Tim Søgaard} & 11 \\
+		Jens Fogh-Andersen & 1614 & Morten Lind & 413 & Christoffer Green Sørensen & 115 & \textbf{Flemming Haslund} & 10 \\
+		Ole Jensen & 1611 & Esben Agerlin Olsen & 406 & Flemming Junker & 103 & \textbf{Henrik Nordstrøm Mortensen} & 10 \\
+		David Højmark & 1549 & Carsten Hougaard & 406 & Niklas Grønborg & 103 & \textbf{Emil Halkær} & 9 \\
+		Niels Hansen & 1512 & Dorit Glintborg & 405 & Sofie Møller & 99 & \textbf{Katrine Hjulmann Nielsen} & 9 \\
+		Line Lykkegaard Skou & 1504 & Karin Pedersen & 397 & Michael Strandfelt & 98 & \textbf{John Jensen} & 8 \\
+		Lars Bang Bertelsen & 1443 & Kasper Ørkild & 393 & Anders Sønderup & 95 & \textbf{Jacob Eggert Kabel} & 8 \\
+		Villy Dall & 1408 & Marianne Isen & 387 & Søren Kjær & 95 & \textbf{Søren Dietrichsen} & 7 \\
+		Hans Peter Kragh & 1403 & Jakob Gammelgaard & 385 & Lone Beck & 92 & \textbf{Nicolai Østergaard} & 6 \\
+		Claus T. Kræmmergård & 1354 & Dorte Geertsen & 383 & Torben O. Andersen & 91 & \textbf{Søren L. Hviid} & 6 \\
+		Lars Christensen & 1293 & Torben Duch Holm & 364 & Mikkel Færgemann Viken & 91 & \textbf{Kathrine Lykkegaard Jeppesen} & 5 \\
+		Rasmus Skovbo & 1253 & Henrik Strømgaard & 362 & Hans Henrik Rasmussen & 90 & \textbf{Ursula Rechnagel Taylor} & 5 \\
+		Anders Abildgaard & 1229 & Lisbeth Helleskov & 361 & Steffen Bek & 89 & \textbf{Jens Otto Barsøe} & 4 \\
+		Lasse Damsgaard & 1209 & Niels Brauer & 358 & Simon Kjær Jensen & 86 & \textbf{Maria Berg Badstue Pedersen} & 4 \\
+		Søren Østergaard & 1207 & Jesper Poulsen & 348 & Michael Sand & 85 & \textbf{Jacob Andersen} & 3 \\
+		Hanne Lindblad Jensen & 1191 & Lars Termansen & 328 & Julian Drud Sørensen & 84 & \textbf{Christian Brahe-Pedersen} & 3 \\
+		Charlotte Bøje & 1117 & Mikkel Eklund & 328 & Tina Larsen & 82 & \textbf{Helle-Lise Ritzau Kaptain} & 3 \\
+		Morten Kyndby Holm & 1102 & Susie Skov & 323 & Nils Rasmussen & 79 & \textbf{Jane Schmidt Klausen} & 3 \\
+		Lars Aare Jensen & 1084 & Birgitte Sonne & 321 & Katrine Hjulmann & 73 & \textbf{Ebbe Fischer} & 3 \\
+		Hanne Overbye & 1075 & Anders Andersen & 315 & Mathias Lykke & 72 & \textbf{Stefan Buur Hansen} & 3 \\
+		Lise Stenbro & 1029 & Gunnar Onghamar & 309 & Caspar Birk & 71 & \textbf{Camilla Pehrson} & 2 \\
+		Lone Lærke Krog & 1005 & Carl Emil Nielsen & 305 & Anna Bech Sørensen & 69 & \textbf{Danske Fagmedier master} & 2 \\
+		Carsten Tolbøll & 1004 & Emma Toftelund Poulsen & 299 & Fie Dømler & 65 & \textbf{testbruger} & 2 \\
+		Mette Møller & 974 & Ole Sanvig Knudsen & 287 & Poul Christoffersen & 65 & \textbf{Anders Fuglsang} & 2 \\
+		Ida Smith & 973 & Charlotte Rørth & 276 & Søren Skov & 56 & \textbf{Peter Kargaard} & 2 \\
+		Merete Horn & 929 & Morten Appel & 273 & Nana Sofia Hansen & 54 & \textbf{Morten Munk Andersen} & 2 \\
+		Pernille K. Damsgaard & 922 & Kristian Gull Pedersen & 266 & Tobias Reffstrup Rasmussen & 53 & \textbf{JSLbruger Nordjyske} & 2 \\
+		Lars Løcke & 873 & Birgitte Bové & 262 & AAArtikler parkeret & 51 & \textbf{Jan M. Jensen} & 1 \\
+		Thomas Nielsen & 841 & Helle Madsen & 258 & Camilla Gammelgaard Johansen & 50 & \textbf{Tom Andersson} & 1 \\
+		Jakob Frey Ahrentzen & 832 & Kasper Orkild Hansen & 255 & Klaus Færch Gjerulff & 49 & \textbf{Jørgen la Cour-Harbo} & 1 \\
+		Lise Myrup Lassen & 793 & Emil Abkjær Kristensen & 253 & Ida Thorsen & 48 & \textbf{Rene Sonne} & 1 \\
+		Carl Chr. Madsen & 785 & Nanna Holm Hansen & 252 & Mathias Overgaard & 46 & \textbf{SAXoTECH Systembruger} & 1 \\
+		Inge Nørregård & 746 & Bine Martine Gori & 247 & Kirsten Østergaard & 45 & \textbf{Andreas K. Wielandt} & 1 \\
+		Jesper Schouenborg & 724 & Heidi Majgaard B. Pedersen & 244 & Gerda Buhl Andersen & 44 & \textbf{Per Lyngby} & 1 \\
+		Jens Sønderup & 709 & Daniel Vendner & 211 & Pia Christensen & 44 & \textbf{Michael F. Nørfelt} & 1 \\
+		Birgit Eriksen & 700 & Ida Marie Kristensen & 204 & Dorte Rohde & 42 & \textbf{Simon Dinsen Hansen} & 1 \\
+		Søren Wormslev & 681 & Kirsten Pilgaard & 197 & Anna Grethe Jensen & 41 & \textbf{Mads Skov Aagurd} & 1 \\
+		Knud Labohn & 653 & Marianne Dyhrberg Cornett & 192 & Henrik Schulz & 38 & \textbf{Benita Dreyer-Andersen} & 1 \\
+		Hans Jørgen Hansen & 646 & Susanne Justsen & 191 & Lone Heilskov & 37 & & \\
 		\bottomrule
 	\end{tabular}
 \end{table*}

--- a/sections/appendix/categories.tex
+++ b/sections/appendix/categories.tex
@@ -3,7 +3,7 @@
 \subsubsection{Category}\label{subsec:appendix_category}
 
 There are $58$ different category labels present within the dataset.
-Categories with fewer than 139 documents ($0.1\%$ of the number of documents) are removed as part of preprocessing and replaced with a single miscellaneous category 'misc'.
+Categories with less than 140 documents ($0.1\%$ of the number of documents) are removed as part of preprocessing and replaced with a single miscellaneous category 'misc'.
 This reduces the number of categories to $34$, while only replacing 292 documents to have the 'misc' category.
 This preprocessing also makes the size of the remaining categories more evenly distributed, as can be seen in \autoref{fig:category_hist}.
 
@@ -43,10 +43,13 @@ From the exploration of these two categories, we can not say with certainty why 
 We continue to use these categories in our experiment, for the possibility of making other observations through the topic models.
 
 \begin{table*}[h]
+	\caption{Number of documents for each of the 58 categories within the Nordjyske dataset from 2017 to 2019.
+		The highlighted categories are filtered and combined during preprocessing.}
+	\label{tab:category_table}
 	\centering
 	\begin{tabular}{l|c|l|c|l|c|l|c}
 		Category            & Number & Category        & Number & Category                       & Number & Category                    & Number \\
-		\toprule
+		\midrule
 		Fælles              & 20204  & Navne           &  3749  & Kram                           &  244   & \textbf{Østvendsyssel Avis} &   4    \\
 		Thisted-avis        & 11473  & Kultur          &  3012  & 53. Frederik                   &  203   & \textbf{DF Motor Biler}     &   3    \\
 		Sport-avis          & 10941  & Morsø Sport     &  2350  & Feature                        &  188   & \textbf{Nyhedsmotoren-net}  &   3    \\
@@ -64,9 +67,6 @@ We continue to use these categories in our experiment, for the possibility of ma
 		Jammerbugt-avis     &  3791  & 26. Frederik    &  484   & \textbf{DF Licitation Diverse} &   4    &                             &        \\
 		\bottomrule
 	\end{tabular}
-	\caption{Number of documents for each of the 58 categories within the Nordjyske dataset from 2017 to 2019.
-		The highlighted categories are filtered and combined during preprocessing.}
-	\label{tab:category_table}
 \end{table*}
 \todo[inline]{mark categories that are preprocessed away}
 
@@ -127,6 +127,8 @@ Out of $1135$ sub-taxonomies, $779$ are removed during this preprocessing.
 \todo[inline]{describe layer sizes of taxonomy tree}
 
 \begin{table}
+	\caption{Statistics over documents associated with metadata values, before and after preprocessing}
+	\label{tab:meta_prepro_stats}
 	\centering
 	\begin{tabular}{l | c | c | c | c | c}
 		Metadata & Min & Max & Mean & Median & Std. \\
@@ -138,6 +140,4 @@ Out of $1135$ sub-taxonomies, $779$ are removed during this preprocessing.
 		Taxonomy & 1 & 29535 & 123.0 & 6 & 1385.9 \\
 		Taxonomy (preprocessed) & 14 & 29535 & 1598.9 & 118.5 & 9298.4 \\
 	\end{tabular}
-	\caption{Statistics over documents associated with metadata values, before and after preprocessing}
-	\label{tab:meta_prepro_stats}
 \end{table}

--- a/sections/appendix/categories.tex
+++ b/sections/appendix/categories.tex
@@ -1,7 +1,4 @@
-\subsection{Metadata labels}\label{sec:appendix_meta_data}
-
 \subsubsection{Category}\label{subsec:appendix_category}
-
 There are $58$ different category labels present within the dataset.
 Categories with less than 140 documents ($0.1\%$ of the number of documents) are removed as part of preprocessing and replaced with a single miscellaneous category 'misc'.
 This reduces the number of categories to $34$, while only replacing 292 documents to have the 'misc' category.
@@ -68,76 +65,3 @@ We continue to use these categories in our experiment, for the possibility of ma
 		\bottomrule
 	\end{tabular}
 \end{table*}
-\todo[inline]{mark categories that are preprocessed away}
-
-
-\subsubsection{Author}\label{subsec:appendix_author}
-Unlike with Categories, the Author metadata field does not have a natural cut-off point, with a good amount of values in a specific lower range, followed by more evenly distributed numbers.
-Instead, the vast majority of the values fall in a lower range, meaning that setting too high a cut-off point, will result in removing a large portion of the data.
-We instead choose a lower cut-off point, keeping most of the authors, except the ones that contained so few documents, that finding common topics would be inefficient.
-Authors, who have written less than $14$ documents ($0.01\%$ of the number of documents), are removed as part of preprocessing.
-This removes $43$ out of $227$ authors, combining them into a single 'misc' author.
-A total of $204$ documents are assigned to the 'misc' author.
-\todo[inline]{figure out whether to use boxplots or histograms, and ref them.}
-
-\begin{figure*}[ht]
-	\centering
-	\begin{subfigure}{0.45\textwidth}
-		\centering
-		\includegraphics[width=\linewidth]{figures/author_hist2_before.png}
-		\caption{Before preprocessing}
-		\label{fig:author_hist_before}
-	\end{subfigure}
-	\begin{subfigure}{0.45\textwidth}
-		\centering
-		\includegraphics[width=\linewidth]{figures/author_hist2_14.png}
-		\caption{After preprocessing}
-		\label{fig:auhtor_hist_after}
-	\end{subfigure}
-	\caption{Histogram over amount authors who have written certain number of documents, before and after preprocessing.
-	Authors on the x-axis are grouped into 50 buckets.}
-	\label{fig:author_hist}
-\end{figure*}
-
-\begin{figure*}[ht]
-	\centering
-	\begin{subfigure}{0.45\textwidth}
-		\centering
-		\includegraphics[width=\linewidth]{figures/author_box_before.png}
-		\caption{Before preprocessing}
-		\label{fig:author_box_before}
-	\end{subfigure}
-	\begin{subfigure}{0.45\textwidth}
-		\centering
-		\includegraphics[width=\linewidth]{figures/author_box_14.png}
-		\caption{After preprocessing}
-		\label{fig:auhtor_box_after}
-	\end{subfigure}
-	\caption{Boxplot over the amount of documents written by authors.}
-	\label{fig:author_box}
-\end{figure*}
-
-\subsubsection{Taxonomy}\label{subsec:appendix_taxonomy}
-Taxonomy is fundamentally different from the other metadata fields, in this paper.
-It is not fully observed with only roughly $25\%$ of documents having a taxonomy field.
-It is hierarchical, with each taxonomy containing a sequence of sub-taxonomies, such as: 'STEDER/Danmark/Nordjylland/Aalborg'.
-It is also possible for each document to have multiple taxonomy sequences.
-Like with authors, we remove any sub-taxonomy that is used in less than $14$ taxonomy sequences ($0.01\%$ of the number of documents).
-Out of $1135$ sub-taxonomies, $779$ are removed during this preprocessing.
-\todo[inline]{describe layer sizes of taxonomy tree}
-
-\begin{table}
-	\caption{Statistics over documents associated with metadata values, before and after preprocessing}
-	\label{tab:meta_prepro_stats}
-	\centering
-	\begin{tabular}{l | c | c | c | c | c}
-		Metadata & Min & Max & Mean & Median & Std. \\
-		\hline
-		Author & 1 & 9893 & 612.6 & 191 & 1219.7 \\
-		Author (preprocessed) & 15 & 9893 & 751.7 & 323 & 1311.9 \\
-		Category & 1 & 20204 & 2397.6 & 548 & 3812.1 \\
-		Category (preprocessed) & 188 & 20204 & 4090.0 & 2681 & 4227.3 \\
-		Taxonomy & 1 & 29535 & 123.0 & 6 & 1385.9 \\
-		Taxonomy (preprocessed) & 14 & 29535 & 1598.9 & 118.5 & 9298.4 \\
-	\end{tabular}
-\end{table}

--- a/sections/appendix/metadata_labels.tex
+++ b/sections/appendix/metadata_labels.tex
@@ -5,3 +5,21 @@ Here the focus will be on observations related to the labels of the metadata.
 \input{sections/appendix/categories.tex}
 \input{sections/appendix/authors.tex}
 \input{sections/appendix/taxonomies.tex}
+
+Statistics over the three metadata types, before and after preprocessing, can be seen in \autoref{tab:meta_prepro_stats}.
+
+\begin{table}
+	\caption{Statistics over documents associated with metadata values, before and after preprocessing.}
+	\label{tab:meta_prepro_stats}
+	\centering
+	\begin{tabular}{l | c | c | c | c | c}
+		Metadata & Min & Max & Mean & Median & Std. \\
+		\midrule
+		Author & 1 & 9893 & 612.6 & 191 & 1219.7 \\
+		Author (preprocessed) & 15 & 9893 & 751.7 & 323 & 1311.9 \\
+		Category & 1 & 20204 & 2397.6 & 548 & 3812.1 \\
+		Category (preprocessed) & 188 & 20204 & 4090.0 & 2681 & 4227.3 \\
+		Taxonomy & 1 & 29535 & 123.0 & 6 & 1385.9 \\
+		Taxonomy (preprocessed) & 14 & 29535 & 1598.9 & 118.5 & 9298.4 \\
+	\end{tabular}
+\end{table}

--- a/sections/appendix/metadata_labels.tex
+++ b/sections/appendix/metadata_labels.tex
@@ -1,0 +1,7 @@
+\subsection{Metadata labels}\label{sec:appendix_meta_data}
+In this section, the different types of metadata used in our evaluations will be explored. 
+Here the focus will be on observations related to the labels of the metadata.
+
+\input{sections/appendix/categories.tex}
+\input{sections/appendix/authors.tex}
+\input{sections/appendix/taxonomies.tex}

--- a/sections/appendix/taxonomies.tex
+++ b/sections/appendix/taxonomies.tex
@@ -9,7 +9,7 @@ A subset of the taxonomies and the number of articles they appear in can be seen
 \todo[inline]{describe layer sizes of taxonomy tree}
 
 For the labels in \autoref{tab:taxonomy_table}, the counts show the labels' sizes.
-It is worth mentioning that, while the counts of the labels are directly linked the amount of documents in the whole dataset, they are also connected to the size of the previous layer's taxonomy.
+It is worth mentioning that, while the counts of the labels are directly linked to the number of documents in the whole dataset, they are also connected to the size of the previous layer's taxonomy.
 For example, the label 'Danmark' is in the layer below the 'STEDER' label, where the 26145 documents of 'Danmark' is a subset of the 29535 documents of 'STEDER'.
 
 There is also a much larger number of 'STEDER' (places) documents compared to 'EMNER' (subjects) documents, respectively 29535 compared to 5449.

--- a/sections/appendix/taxonomies.tex
+++ b/sections/appendix/taxonomies.tex
@@ -1,0 +1,66 @@
+\subsection{Taxonomy metadata}\label{sec:appendix_taxonomy}
+
+
+\begin{table*}[h]
+	\caption{Number of documents written by each taxonomy in the Nordjyske dataset from 2017 to 2019.
+	After sorting by the number of documents, only the first 100 and last 100 taxonomies are shown.
+	The highlighted taxonomies are filtered and combined during preprocessing.}
+	\label{tab:taxonomy_table}
+	\centering
+	\scriptsize
+	\begin{tabular}{l|c|l|c|l|c|l|c}
+		Taxonomy                & Number & Taxonomy                     & Number & Taxonomy                       & Number & Taxonomy                       & Number \\
+		\midrule
+		\emph{No taxonomy} & 103928 & Farsø & 182 & \textbf{Mallorca} & 1 & \textbf{Mali} & 1 \\
+		STEDER & 29535 & Skørping & 177 & \textbf{Kloning} & 1 & \textbf{Godstransport} & 1 \\
+		Danmark & 26145 & Hurup & 169 & \textbf{Hjørring revyen} & 1 & \textbf{Energiforbrug} & 1 \\
+		Nordjylland & 23274 & Dronninglund & 167 & \textbf{Fredensborg} & 1 & \textbf{Gedser} & 1 \\
+		EMNER & 5449 & Fjerritslev & 165 & \textbf{Iværksættere} & 1 & \textbf{Mylund} & 1 \\
+		Thisted & 3592 & Aabybro & 163 & \textbf{Tall ships races} & 1 & \textbf{Bygge- og anlægsbranchen} & 1 \\
+		Udland & 3390 & Frankrig & 159 & \textbf{Sproget} & 1 & \textbf{Kunstig intelligens} & 1 \\
+		Aalborg & 3311 & Sverige & 158 & \textbf{Grurup} & 1 & \textbf{Nielstrup} & 1 \\
+		Hjørring & 2146 & Paris & 157 & \textbf{Hørning} & 1 & \textbf{Kristiansand} & 1 \\
+		Frederikshavn & 1997 & Fyn & 156 & \textbf{Hem} & 1 & \textbf{Nordborg} & 1 \\
+		Mariagerfjord & 1987 & Rusland & 151 & \textbf{Floorball} & 1 & \textbf{Uggerhalne} & 1 \\
+		Brønderslev & 1969 & Ulykker & 150 & \textbf{Store Brøndum} & 1 & \textbf{Barmer} & 1 \\
+		Vesthimmerland & 1660 & Aarhus & 145 & \textbf{Korup} & 1 & \textbf{Narkomisbrug} & 1 \\
+		Hovedstadsområdet & 1380 & Tyskland & 144 & \textbf{Fødevaresikkerhed} & 1 & \textbf{Adoption} & 1 \\
+		Rebild & 1289 & Moskva & 143 & \textbf{Hammershøj} & 1 & \textbf{Fødevareindustri} & 1 \\
+		Jammerbugt & 1198 & Arden & 142 & \textbf{Hjerneskade} & 1 & \textbf{Smugling} & 1 \\
+		København & 1125 & Politik & 139 & \textbf{CATEGORY} & 1 & \textbf{Skikke og traditioner} & 1 \\
+		Hobro & 996 & Morsø & 137 & \textbf{AaB Plus} & 1 & \textbf{Kigali} & 1 \\
+		Aalborg og omegn & 833 & Berlin & 132 & \textbf{Ekstremsport} & 1 & \textbf{Holtet} & 1 \\
+		Thisted og omegn & 800 & Sjælland & 131 & \textbf{Mozambique} & 1 & \textbf{Fritidshuse} & 1 \\
+		Midtjylland & 783 & Løkken & 129 & \textbf{Maputo} & 1 & \textbf{Årslev} & 1 \\
+		Mors & 630 & New York & 124 & \textbf{Handelsskole} & 1 & \textbf{Aalborg Håndbold} & 1 \\
+		Aars & 540 & Natur & 123 & \textbf{Vendsyssel Håndbold} & 1 & \textbf{Oman} & 1 \\
+		USA & 478 & Erhverv & 119 & \textbf{Biludstyr} & 1 & \textbf{Turistbranchen} & 1 \\
+		Frederikshavn og omegn & 410 & Spanien & 119 & \textbf{Brandstiftelse} & 1 & \textbf{Øl} & 1 \\
+		Sport & 408 & Klitmøller & 118 & \textbf{Nørre Dråby} & 1 & \textbf{Forlystelsespark} & 1 \\
+		England & 381 & Aalestrup & 118 & \textbf{Stae} & 1 & \textbf{Etiopien} & 1 \\
+		London & 379 & Herning & 116 & \textbf{Rebild Bakker} & 1 & \textbf{Addis Abeba} & 1 \\
+		Hjørring og omegn & 369 & Stockholm & 115 & \textbf{Kampsport} & 1 & \textbf{Lystsejlads} & 1 \\
+		Løgstør & 368 & Madrid & 115 & \textbf{Lynnedslag} & 1 & \textbf{Herfølge} & 1 \\
+		Mariagerfjord og omegn & 364 & Jerslev & 113 & \textbf{Frederikshavn White Hawks} & 1 & \textbf{Sexchikane} & 1 \\
+		Brønderslev og omegn & 360 & Nørager & 111 & \textbf{Paraguay} & 1 & \textbf{Gebyrer} & 1 \\
+		Skagen & 341 & Sundhed & 105 & \textbf{Asuncion} & 1 & \textbf{Frederikssund} & 1 \\
+		Sæby & 334 & Sindal & 105 & \textbf{Nordkraft} & 1 & \textbf{Gadeuorden} & 1 \\
+		Vesthimmerland og omegn & 327 & Brovst & 105 & \textbf{Vendsyssel Elite Badminton} & 1 & \textbf{Mjels} & 1 \\
+		Syddanmark & 301 & Trafik & 99 & \textbf{Tonga} & 1 & \textbf{Katmandu} & 1 \\
+		Støvring & 300 & Blokhus & 95 & \textbf{Efteruddannelse} & 1 & \textbf{Militærøvelser} & 1 \\
+		Hadsund & 277 & Lønstrup & 92 & \textbf{Vin} & 1 & \textbf{Fakse} & 1 \\
+		Hanstholm & 276 & Uddannelse & 91 & \textbf{Årup} & 1 & \textbf{Kulturpolitik} & 1 \\
+		Kultur & 246 & Pandrup & 88 & \textbf{Fiskeripolitik} & 1 & \textbf{Skræm} & 1 \\
+		Rebild og omegn & 245 & Vrå & 88 & \textbf{Gudumlund} & 1 & \textbf{Taiwan} & 1 \\
+		Washington & 242 & Vorupør & 86 & \textbf{Myrhøj} & 1 & \textbf{Taipei} & 1 \\
+		Jammerbugt og omegn & 229 & Øster Hurup & 85 & \textbf{Ejerslev Lyng} & 1 & \textbf{Økonomisk kriminalitet} & 1 \\
+		Nørresundby & 223 & Hvalpsund & 82 & \textbf{La Paz} & 1 & \textbf{Udviklingsbistand} & 1 \\
+		Mariager & 214 & Odense & 82 & \textbf{Byplanlægning} & 1 & \textbf{Kollerup} & 1 \\
+		Belgien & 207 & Aså & 80 & \textbf{Ajstrup} & 1 & \textbf{Askildrup} & 1 \\
+		Bruxelles & 207 & Norge & 79 & \textbf{Guatemala} & 1 & \textbf{Helsinge} & 1 \\
+		Hirtshals & 197 & INDHOLDSTYPER & 79 & \textbf{Vedsted} & 1 & \textbf{Albanien} & 1 \\
+		Kriminalitet & 192 & Videnskab & 78 & \textbf{Yemen} & 1 & \textbf{Tirana} & 1 \\
+		Hjallerup & 190 & Israel & 78 & \textbf{Skovsted} & 1 & \textbf{Jern \& maskinindustrien} & 1 \\
+		\bottomrule
+	\end{tabular}
+\end{table*}

--- a/sections/appendix/taxonomies.tex
+++ b/sections/appendix/taxonomies.tex
@@ -1,4 +1,28 @@
-\subsection{Taxonomy metadata}\label{sec:appendix_taxonomy}
+\subsubsection{Taxonomy}\label{subsec:appendix_taxonomy}
+Taxonomy is fundamentally different from the other metadata fields, in this paper.
+It is not fully observed with only roughly $25\%$ of documents having a taxonomy field.
+It is hierarchical, with each taxonomy containing a sequence of sub-taxonomies, such as: 'STEDER/Danmark/Nordjylland/Aalborg'.
+It is also possible for each document to have multiple taxonomy sequences.
+Like with authors, we remove any sub-taxonomy that is used in less than $14$ taxonomy sequences ($0.01\%$ of the number of documents).
+Out of $1135$ sub-taxonomies, $779$ are removed during this preprocessing.
+\todo[inline]{describe layer sizes of taxonomy tree}
+
+\begin{table}
+	\caption{Statistics over documents associated with metadata values, before and after preprocessing}
+	\label{tab:meta_prepro_stats}
+	\centering
+	\begin{tabular}{l | c | c | c | c | c}
+		Metadata & Min & Max & Mean & Median & Std. \\
+		\midrule
+		Author & 1 & 9893 & 612.6 & 191 & 1219.7 \\
+		Author (preprocessed) & 15 & 9893 & 751.7 & 323 & 1311.9 \\
+		Category & 1 & 20204 & 2397.6 & 548 & 3812.1 \\
+		Category (preprocessed) & 188 & 20204 & 4090.0 & 2681 & 4227.3 \\
+		Taxonomy & 1 & 29535 & 123.0 & 6 & 1385.9 \\
+		Taxonomy (preprocessed) & 14 & 29535 & 1598.9 & 118.5 & 9298.4 \\
+	\end{tabular}
+\end{table}
+
 
 
 \begin{table*}[h]

--- a/sections/appendix/taxonomies.tex
+++ b/sections/appendix/taxonomies.tex
@@ -5,25 +5,20 @@ It is hierarchical, with each taxonomy containing a sequence of sub-taxonomies, 
 It is also possible for each document to have multiple taxonomy sequences.
 Like with authors, we remove any sub-taxonomy that is used in less than $14$ taxonomy sequences ($0.01\%$ of the number of documents).
 Out of $1135$ sub-taxonomies, $779$ are removed during this preprocessing.
+A subset of the taxonomies and the number of articles they appear in can be seen in \autoref{tab:taxonomy_table}.
 \todo[inline]{describe layer sizes of taxonomy tree}
 
-\begin{table}
-	\caption{Statistics over documents associated with metadata values, before and after preprocessing}
-	\label{tab:meta_prepro_stats}
-	\centering
-	\begin{tabular}{l | c | c | c | c | c}
-		Metadata & Min & Max & Mean & Median & Std. \\
-		\midrule
-		Author & 1 & 9893 & 612.6 & 191 & 1219.7 \\
-		Author (preprocessed) & 15 & 9893 & 751.7 & 323 & 1311.9 \\
-		Category & 1 & 20204 & 2397.6 & 548 & 3812.1 \\
-		Category (preprocessed) & 188 & 20204 & 4090.0 & 2681 & 4227.3 \\
-		Taxonomy & 1 & 29535 & 123.0 & 6 & 1385.9 \\
-		Taxonomy (preprocessed) & 14 & 29535 & 1598.9 & 118.5 & 9298.4 \\
-	\end{tabular}
-\end{table}
+For the labels in \autoref{tab:taxonomy_table}, the counts show the labels' sizes.
+It is worth mentioning that, while the counts of the labels are directly linked the amount of documents in the whole dataset, they are also connected to the size of the previous layer's taxonomy.
+For example, the label 'Danmark' is in the layer below the 'STEDER' label, where the 26145 documents of 'Danmark' is a subset of the 29535 documents of 'STEDER'.
 
+There is also a much larger number of 'STEDER' (places) documents compared to 'EMNER' (subjects) documents, respectively 29535 compared to 5449.
+In \autoref{tab:taxonomy_table}, the first label on a lower layer that comes from 'EMNER' is 'Sport' with 408 documents.
+This gives an indication that the subject taxonomies in general are much smaller in size.
+The \gls{pam} will then be mostly influenced by this location information compared to actual topical labels.
 
+The labels removed during preprocessing appear, as expected, to be places or subjects that have been written about just once or a few times.
+We could have combined them into a 'misc' taxonomy as we did for the category and author metadata, but decided against it because it would just be a large collection of mostly random documents.
 
 \begin{table*}[h]
 	\caption{Number of documents written by each taxonomy in the Nordjyske dataset from 2017 to 2019.

--- a/sections/appendix/taxonomies.tex
+++ b/sections/appendix/taxonomies.tex
@@ -14,7 +14,7 @@ For example, the label 'Danmark' is in the layer below the 'STEDER' label, where
 
 There is also a much larger number of 'STEDER' (places) documents compared to 'EMNER' (subjects) documents, respectively 29535 compared to 5449.
 In \autoref{tab:taxonomy_table}, the first label on a lower layer that comes from 'EMNER' is 'Sport' with 408 documents.
-This gives an indication that the subject taxonomies in general are much smaller in size.
+This indicates that the subject taxonomies, in general, are much smaller in size.
 The \gls{pam} will then be mostly influenced by this location information compared to actual topical labels.
 
 The labels removed during preprocessing appear, as expected, to be places or subjects that have been written about just once or a few times.


### PR DESCRIPTION
Omstruktureret metadata labels afsnittet så der er tydeligere sammenhæng. Tilføjede også taxonomy tabellen med counts af dokumenter og beskrev nogle observationer ud fra dette. Der er også rettet/tilføjet små ting rundt omkring.