### PR TITLE
Related works changes

### DIFF
--- a/paper.tex
+++ b/paper.tex
@@ -66,8 +66,7 @@ rech16@student.aau.dk}
 % - Introduction (7.5 \%) 
 \input{sections/introduction.tex}
 %
-%% - Related works (7.5 \%))
-\input{sections/related_works.tex}
+
 %
 %% - Preliminaries/"Experiment" (20 \%)
 %%		- Data
@@ -76,6 +75,10 @@ rech16@student.aau.dk}
 
 
 \input{sections/Dataset.tex}
+
+%% - Related works (7.5 \%))
+\input{sections/related_works.tex}
+
 \input{sections/preliminaries.tex}
 \input{sections/plate_notation.tex}
 

--- a/sections/futureWork.tex
+++ b/sections/futureWork.tex
@@ -1,4 +1,5 @@
 \section{Future Work}\label{sec:future_work}
+\todo[inline]{Consider making future work a subsection to the conclusion, or having the text as part of the conclusion without a section}
 Due to the promising results provided by the modified pachinko model, investigating this model further might be beneficial to incorporating metadata into topic models.
 However, testing these models on multiple datasets needs to be accounted for since the generalizability of these models is not explored within this paper.
 Using word embedding to further improve the performance of models can also be viewed as a possible next step for this project since a wide number of papers are using this technique to improve topic modeling.

--- a/sections/introduction.tex
+++ b/sections/introduction.tex
@@ -58,9 +58,9 @@ These categorical metadata are the basis for the novelties in this paper, which 
 
 % Paper Structure
 The paper is organized as follows:
-In \autoref{sec:related_work}, we explore related work within topic modeling using metadata.
 \autoref{sec:dataset} describes the dataset and the metadata used in the evaluation.
-In \autoref{sec:plate_notation}, \gls{lda} and the metadata topic models are described, and their plate notation is shown.
+In \autoref{sec:related_work}, we explore related work within topic modeling using metadata.
+\autoref{sec:preliminaries} gives preliminary knowledge about the topic models we adapt, and \autoref{sec:plate_notation} describes our metadata topic models and shows the plate notation.
 In \autoref{sec:experiment}, we set up an evaluation to test the performance of the different metadata topic models and present the results.
 In \autoref{sec:discussion}, we analyze and discuss the results of our topic models.
 Finally, in \autoref{sec:conclusion}, conclusions and future work are given.

--- a/sections/related_works.tex
+++ b/sections/related_works.tex
@@ -8,9 +8,8 @@ This way the model learns assignments of the words in each document to the metad
 The models we create follow the upstream pattern.
 
 \citet{author_topic_2012} have developed an \gls{lda} model called the Author-Topic model, which incorporates authorship information in the \gls{lda} model.
-Specifically, each document has a vector of authors, where for each word an author is drawn from this vector.\vejleder[inline]{er dette korrekt?}
-The author is then used in combination with an author-topic distribution to draw a specific topic that this author writes about.
-The words from the topic-word distribution can be generated based on this topic.
+Specifically, each document has a group of authors, where for each word an author is chosen uniformly at random.
+The author is then used in combination with an author-topic distribution to choose a specific topic that this author writes about, and the word is then generated from this topic.
 The purpose of using authorship information in this way, is to show patterns in which topics an author usually writes about, and be able to explore how related authors are in what they write about.
 \citeauthor{author_topic_2012} also show that the combination of authorship and \gls{lda} yield more coherent topics.
 However, the Author-Topic model from \citet{author_topic_2012} is applied to scientific article datasets, where the authors usually write about the same subject.
@@ -20,20 +19,17 @@ We apply this model to the Nordjyske news article dataset to see whether similar
 Since the field of incorporating word embeddings within generative topic models have gained popularity\cite{dieng2020topic}, \citet{MetaLDA2017} show how to use this information for a variety of different datasets.
 They also compare against a list of other models that take either metadata information or word embeddings into account when doing inference.
 We take inspiration from \citet{MetaLDA2017}, but we do not employ the model they present. 
-We use the Author-Topic model instead of MetaLDA because, in MetaLDA, each document has a specific Dirichlet prior for its topic distribution, making it difficult to analyze a model that includes multiple metadata fields.
+We use the Author-Topic model instead of MetaLDA because, in MetaLDA, each document has a specific Dirichlet prior for its topic distribution, which is computed from the metadata of the document, making it difficult to analyze the effect of a specific metadata type in a model that includes multiple metadata fields.
 
 \citet{tea_leaves} present different methods for evaluating probabilistic topic models. 
 An important observation they made is that a good held-out likelihood, normally called perplexity, infers less semantically meaningful topics.
-They also present two different human judgment methods called \emph{word intrusion} and \emph{topic intrusion}, which can be used to evaluate topic models by human judgment. 
-\emph{Word intrusion} is where an "intrusion" word has been placed into a coherent topic, and the task is to identify the word.
-\emph{Topic intrusion} is a task where a set of topics and a document are given, and the goal is to identify the topic that does not associate with the document. 
 \citet{topic_coherence_2015} introduce new measures for evaluating topic models, where some of them use the co-occurrence or conditional probability of words within topics to measure how coherent the topics are. 
 In order to verify that these metrics work, they conduct a large user study in conjunction with these metric evaluations.
 We use the evaluation metrics presented in \citet{topic_coherence_2015} to evaluate the topic quality of each of our models.
 
 \citet{li2006pachinko} present a \gls{dag} structured topic model, called the \acrfull{pam}, where topics are in a hierarchical structure, which allows it to find two types of topics, namely super-topics and sub-topics. 
 \Gls{pam} is a generalization of the \gls{lda} model, where super and sub-topics are used to correlate topics within the model, e.g. a football topic being part of a sports topic.
-We have a metadata field within our dataset, which is hierarchically structured. \vejleder[inline]{måske presenter data-afsnit først?}
+We have a hierarchically structured taxonomy metadata field within our dataset, which fits well with the hierarchical structure of this model.
 We create a modified \gls{pam} to account for this metadata field and investigate whether this type of information can improve the topic quality.
 
 There also exist a variety of models that look at either document or word metadata.
@@ -43,9 +39,15 @@ DMR handles metadata similarly to MetaLDA~\cite{MetaLDA2017} by incorporating la
 Examples of models that incorporate word-level metadata are: WF-LDA by \citet{wf-lda2010} and LF-LDA by \citet{lf-lda2015}.
 WF-LDA extends \gls{lda} by using word features to make a prior for the topics.
 LF-LDA takes the approach of replacing \gls{lda}'s topic-word Dirichlet multinomial component with a two-component mixture of a topic-word Dirichlet multinomial component and a latent feature component.
+We focus specifically on document-level metadata, since this is easily available in our dataset.
 
-From these works, we adapt the concepts from \citet{author_topic_2012}\vejleder{argumenter ud fra data + formål} for how we use metadata in our models, though with slight changes in the models for handling the characteristics of our data.
-As mentioned earlier, one of the main reasons why we use the concepts from the Author-Topic model instead of the newer MetaLDA model~\cite{MetaLDA2017} is that in MetaLDA, each document has a specific Dirichlet prior for its topic distribution, which is computed from the metadata of the document.\vejleder[inline]{meget vanskeligt at følge med uden indsigt i modellerne}
+Some of these works have shortcomings that we want to account for.
+The model may not be built around incorporating metadata, such as the \gls{pam}~\cite{li2006pachinko}, which then has to be modified.
+The metadata may be incorporated in the model in such a way that a deeper analysis of the becomes difficult, such as with the MetaLDA model~\cite{MetaLDA2017}.
+It may also simply be that the work does not explore multiple types of metadata for their models, which is the case for the author-topic model~\cite{author_topic_2012}.
+
+From these works, we adapt the concepts from \citet{author_topic_2012} for new models that can handle the unique characteristics of our dataset and support a deeper exploration of the models.
+As mentioned earlier, one of the main reasons why we use the concepts from the Author-Topic model instead of the newer MetaLDA model~\cite{MetaLDA2017} is because each document in MetaLDA has a topic distribution that is based on the document's metadata.
 Analyzing such a model that includes multiple metadata can be complicated, while in the author-topic model, other metadata can be included as their own meta-topic distributions and be analyzed further.
 Also, since MetaLDA uses the document-topic distribution as its base, we would not be able to explore other interesting connections, such as the connection between learned category-topic distributions and the topics that are most probable for specific categories.
-We also explore whether adapting the \gls{pam}~\cite{li2006pachinko} to work with a hierarchically structured metadata called 'taxonomy', described in \autoref{sec:dataset_taxonomy}, gives the model more context and improves the topic quality or performance.
+We also explore whether adapting the \gls{pam}~\cite{li2006pachinko} to work with a hierarchically structured taxonomy metadata, described in \autoref{sec:dataset_taxonomy}, gives the model more context and improves the topic quality or performance.


### PR DESCRIPTION
Har rykket related works ned efter dataset afsnittet, så læseren har lidt viden om vores metadata når de læser om hvad vi gør med de forskellige modeller (rækkefølge: intro->dataset->related works->preliminaries). Har også tilføjet en paragraf om shortcomings af nogle af modellerne, og rettet todos.